### PR TITLE
Update examples and index homepage

### DIFF
--- a/docs/src/content/docs/examples/asides.mdx
+++ b/docs/src/content/docs/examples/asides.mdx
@@ -1,64 +1,69 @@
 ---
 title: Asides
+pagefind: false
 ---
 
 ## Markdown asides
 
+Asides rendered with the [custom Markdown syntax](https://starlight.astro.build/guides/authoring-content/#asides) using a pair of triple colons `:::` to wrap your content.
+
 :::note
 
-Donec sollicitudin dolor et sollicitudin [efficitur](#_). Nullam semper posuere lacinia.
+A `note` aside with a [link](#_) in the content.
 
 :::
 
 :::tip
 
-Donec sollicitudin dolor et sollicitudin [efficitur](#_). Nullam semper posuere lacinia.
+A `tip` aside with a [link](#_) in the content.
 
 :::
 
 :::caution
 
-Donec sollicitudin dolor et sollicitudin [efficitur](#_). Nullam semper posuere lacinia.
+A `caution` aside with a [link](#_) in the content.
 
 :::
 
 :::danger
 
-Donec sollicitudin dolor et sollicitudin [efficitur](#_). Nullam semper posuere lacinia.
+A `danger` aside with a [link](#_) in the content.
 
 :::
 
 ## Component asides
 
-import { Aside } from '@astrojs/starlight/components';
+Asides rendered with the [`<Aside>` component](https://starlight.astro.build/components/asides/).
+
+import { Aside } from '@astrojs/starlight/components'
 
 <Aside>
-	Donec sollicitudin dolor et sollicitudin [efficitur](#_). Nullam semper posuere lacinia.
+  A `note` aside with a [link](#_) in the content.
 </Aside>
 
 <Aside type="tip">
-	Donec sollicitudin dolor et sollicitudin [efficitur](#_). Nullam semper posuere lacinia.
+  A `tip` aside with a [link](#_) in the content.
 </Aside>
 
 <Aside type="caution">
-	Donec sollicitudin dolor et sollicitudin [efficitur](#_). Nullam semper posuere lacinia.
+  A `caution` aside with a [link](#_) in the content.
 </Aside>
 
 <Aside type="danger">
-	Donec sollicitudin dolor et sollicitudin [efficitur](#_). Nullam semper posuere lacinia.
+  A `danger` aside with a [link](#_) in the content.
 </Aside>
 
-## With content
+## Asides with content
 
 :::note
 
-Some code:
+A code block:
 
 ```js
-const foo = 'bar';
+const foo = 'bar'
 ```
 
-Some `inline` code
+A sentence with some `inline` code followed by an horizontal rule.
 
 ---
 
@@ -76,9 +81,9 @@ A table:
 A disclosure:
 
 <details>
-<summary>Nullam nec posuere lorem.</summary>
+<summary>The summary of the disclosure</summary>
 
-Aenean tempor, orci eget ullamcorper luctus, nisl turpis pharetra mauris, sit amet tristique elit orci et sem. Aenean odio purus, suscipit quis accumsan in, blandit at ex.
+The content of the [disclosure](https://starlight.astro.build/guides/authoring-content/#details) that can use any other Markdown syntax.
 
 </details>
 
@@ -86,13 +91,13 @@ Aenean tempor, orci eget ullamcorper luctus, nisl turpis pharetra mauris, sit am
 
 :::tip
 
-Some code:
+A code block:
 
 ```js
-const foo = 'bar';
+const foo = 'bar'
 ```
 
-Some `inline` code
+A sentence with some `inline` code followed by an horizontal rule.
 
 ---
 
@@ -110,9 +115,9 @@ A table:
 A disclosure:
 
 <details>
-<summary>Nullam nec posuere lorem.</summary>
+<summary>The summary of the disclosure</summary>
 
-Aenean tempor, orci eget ullamcorper luctus, nisl turpis pharetra mauris, sit amet tristique elit orci et sem. Aenean odio purus, suscipit quis accumsan in, blandit at ex.
+The content of the [disclosure](https://starlight.astro.build/guides/authoring-content/#details) that can use any other Markdown syntax.
 
 </details>
 
@@ -120,13 +125,13 @@ Aenean tempor, orci eget ullamcorper luctus, nisl turpis pharetra mauris, sit am
 
 :::caution
 
-Some code:
+A code block:
 
 ```js
-const foo = 'bar';
+const foo = 'bar'
 ```
 
-Some `inline` code
+A sentence with some `inline` code followed by an horizontal rule.
 
 ---
 
@@ -144,9 +149,9 @@ A table:
 A disclosure:
 
 <details>
-<summary>Nullam nec posuere lorem.</summary>
+<summary>The summary of the disclosure</summary>
 
-Aenean tempor, orci eget ullamcorper luctus, nisl turpis pharetra mauris, sit amet tristique elit orci et sem. Aenean odio purus, suscipit quis accumsan in, blandit at ex.
+The content of the [disclosure](https://starlight.astro.build/guides/authoring-content/#details) that can use any other Markdown syntax.
 
 </details>
 
@@ -154,13 +159,13 @@ Aenean tempor, orci eget ullamcorper luctus, nisl turpis pharetra mauris, sit am
 
 :::danger
 
-Some code:
+A code block:
 
 ```js
-const foo = 'bar';
+const foo = 'bar'
 ```
 
-Some `inline` code
+A sentence with some `inline` code followed by an horizontal rule.
 
 ---
 
@@ -178,9 +183,9 @@ A table:
 A disclosure:
 
 <details>
-<summary>Nullam nec posuere lorem.</summary>
+<summary>The summary of the disclosure</summary>
 
-Aenean tempor, orci eget ullamcorper luctus, nisl turpis pharetra mauris, sit amet tristique elit orci et sem. Aenean odio purus, suscipit quis accumsan in, blandit at ex.
+The content of the [disclosure](https://starlight.astro.build/guides/authoring-content/#details) that can use any other Markdown syntax.
 
 </details>
 

--- a/docs/src/content/docs/examples/badges.mdx
+++ b/docs/src/content/docs/examples/badges.mdx
@@ -1,11 +1,14 @@
 ---
 title: Badges
+pagefind: false
 ---
 
-import { Badge } from '@astrojs/starlight/components';
+Badges rendered with the [`<Badge>` component](https://starlight.astro.build/components/badges/).
 
-<Badge text="New" variant="tip" size="small" />
-<Badge text="Deprecated" variant="caution" size="medium" />
-<Badge text="Rapide" variant="note" size="large" />
-<Badge text="200" variant="success" />
-<Badge text="Experimental" variant="danger" />
+import { Badge } from '@astrojs/starlight/components'
+
+- <Badge text="New" variant="tip" size="small" />
+- <Badge text="Deprecated" variant="caution" size="medium" />
+- <Badge text="Demo" variant="note" size="large" />
+- <Badge text="200" variant="success" />
+- <Badge text="Experimental" variant="danger" />

--- a/docs/src/content/docs/examples/banner-splash.md
+++ b/docs/src/content/docs/examples/banner-splash.md
@@ -1,9 +1,10 @@
 ---
 title: Banner - Splash
+pagefind: false
 template: splash
 banner:
   content: |
-    Aenean eleifend, felis quis <a href="https://example.com">faucibus</a> lobortis, nunc erat interdum turpis, quis consectetur orci mauris eget leo.
+    A <a href="https://starlight.astro.build/reference/frontmatter/#banner">banner</a> displaying an announcement at the top of the page that can include HTML for links or other content.
 ---
 
-A page using the splash template with a banner.
+A page using the [`splash` template](https://starlight.astro.build/reference/frontmatter/#template) with a [banner](https://starlight.astro.build/reference/frontmatter/#banner).

--- a/docs/src/content/docs/examples/banner.md
+++ b/docs/src/content/docs/examples/banner.md
@@ -1,8 +1,9 @@
 ---
 title: Banner
+pagefind: false
 banner:
   content: |
-    Aenean eleifend, felis quis <a href="https://example.com">faucibus</a> lobortis, nunc erat interdum turpis, quis consectetur orci mauris eget leo.
+    A <a href="https://starlight.astro.build/reference/frontmatter/#banner">banner</a> displaying an announcement at the top of the page that can include HTML for links or other content.
 ---
 
-A page with a banner
+A page with a [banner](https://starlight.astro.build/reference/frontmatter/#banner).

--- a/docs/src/content/docs/examples/cards.mdx
+++ b/docs/src/content/docs/examples/cards.mdx
@@ -1,48 +1,59 @@
 ---
 title: Cards
+pagefind: false
 ---
 
-import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
+import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components'
 
-## Single card
+## Card
 
-<Card title="In consectetur diam">
-	Donec sollicitudin dolor et sollicitudin efficitur. Nullam semper posuere lacinia.
+A card rendered with the [`<Card>` component](https://starlight.astro.build/components/cards/).
+
+<Card title="Card title">
+  The content of the card that can use any other Markdown syntax.
 </Card>
 
-## Cards in a grid
+## Card grid
+
+Cards rendered with the [`<Card>` component](https://starlight.astro.build/components/cards/) wrapped with the [`<CardGrid>` component](https://starlight.astro.build/components/card-grids/).
 
 <CardGrid>
-	<Card title="Lorem" icon="star">
-		Fusce ornare ante est.
-	</Card>
-	<Card title="Ipsum" icon="moon">
-		Suspendisse ac tincidunt.
-	</Card>
+  <Card title="Card title" icon="star">
+    The content of the card.
+  </Card>
+  <Card title="Card title" icon="moon">
+    The content of the card.
+  </Card>
 </CardGrid>
 
-## Staggered cards in a grid
+## Staggered card grid
+
+[Staggered](https://starlight.astro.build/components/card-grids/#stagger-cards) cards rendered with the [`<Card>` component](https://starlight.astro.build/components/cards/) wrapped with the [`<CardGrid>` component](https://starlight.astro.build/components/card-grids/).
 
 <CardGrid stagger>
-	<Card title="Lorem" icon="star">
-		Fusce ornare ante est.
-	</Card>
-	<Card title="Ipsum" icon="moon">
-		Suspendisse ac tincidunt.
-	</Card>
+  <Card title="Card title" icon="star">
+    The content of the card.
+  </Card>
+  <Card title="Card title" icon="moon">
+    The content of the card.
+  </Card>
 </CardGrid>
 
-## Single link card
+## Link card
+
+A link card rendered with the [`<LinkCard>` component](https://starlight.astro.build/components/link-cards/).
 
 <LinkCard
-	title="In consectetur diam"
-	description="Donec sollicitudin dolor et sollicitudin efficitur"
-	href="#_"
+  title="Link title"
+  description="The description of the link."
+  href="#_"
 />
 
-## Link cards in a grid
+## Link card grid
+
+Link cards rendered with the [`<LinkCard>` component](https://starlight.astro.build/components/link-cards/) wrapped with the [`<CardGrid>` component](https://starlight.astro.build/components/card-grids/).
 
 <CardGrid>
-	<LinkCard title="Fusce ornare ante est" href="#_" />
-	<LinkCard title="Suspendisse ac tincidunt" href="#_" />
+  <LinkCard title="Link title" href="#_" />
+  <LinkCard title="Link title" href="#_" />
 </CardGrid>

--- a/docs/src/content/docs/examples/code-blocks.mdx
+++ b/docs/src/content/docs/examples/code-blocks.mdx
@@ -1,47 +1,62 @@
 ---
 title: Code Blocks
+pagefind: false
 ---
 
 ## Markdown code block
 
+Code block rendered with the [Markdown syntax](https://starlight.astro.build/guides/authoring-content/#code-blocks) using three backticks <code>```</code> at the start and end.
+
 ```js
-const btn = document.getElementById('btn');
-let count = 0;
-
-function render() {
-	btn.innerText = `Count: ${count}`;
-}
-
-btn.addEventListener('click', () => {
-	// Count from 1 to 10.
-	if (count < 10) {
-		count += 1;
-		render();
-	}
-});
+const foo = 'bar'
 ```
 
 ## `<Code>` component
 
-import { Code } from '@astrojs/starlight/components';
+Code block rendered with the [`<Code>` component](https://starlight.astro.build/components/code/).
+
+import { Code } from '@astrojs/starlight/components'
 
 <Code code="const foo = 'bar'" lang="js" />
 
 ## Text markers
 
+Code blocks with some [text markers](https://expressive-code.com/key-features/text-markers/).
+
 ```js {2}
 function test() {
-	const foo = 'bar';
+  const foo = 'bar'
 }
 ```
 
 ```js "function" ins="foo" del="bar"
 function test() {
-	const foo = 'bar';
+  const foo = 'bar'
 }
 ```
 
+### Labels
+
+Code blocks with some [text markers](https://expressive-code.com/key-features/text-markers/) and [labels](https://expressive-code.com/key-features/text-markers/#adding-labels-to-line-markers).
+
+```astro title="example.astro" {"1. Keep the existing icon.":5-6} del={"2. Remove the button.":8-9} ins={"3. Add a link.":11-12}
+---
+import { Icon } from '@astrojs/starlight/components';
+---
+
+
+<Icon name="seti:lock" />
+
+
+<button type="button">Login</button>
+
+
+<a href="/login/">Login</a>
+```
+
 ## Diff
+
+Code block combining [syntax highlighting with `diff`-like syntax](https://expressive-code.com/key-features/text-markers/#combining-syntax-highlighting-with-diff-like-syntax).
 
 ```diff lang="js"
   function test() {
@@ -50,15 +65,19 @@ function test() {
   }
 ```
 
-## File name
+## Editor frame
+
+Code block with a [file name](https://expressive-code.com/key-features/frames/#code-editor-frames) in the editor frame.
 
 ```js
 // test.js
-const foo = 'bar';
+const foo = 'bar'
 ```
 
-## Terminal window
+## Terminal frame
 
-```bash title="Doing something…"
-pnpm run thing
+Code block with a [terminal frame](https://expressive-code.com/key-features/frames/#terminal-frames).
+
+```bash title="Build something…"
+pnpm run build
 ```

--- a/docs/src/content/docs/examples/draft.md
+++ b/docs/src/content/docs/examples/draft.md
@@ -1,6 +1,7 @@
 ---
 title: Draft
+pagefind: false
 draft: true
 ---
 
-This is a draft.
+A [draft](https://starlight.astro.build/reference/frontmatter/#draft) page not included in production builds.

--- a/docs/src/content/docs/examples/file-tree.mdx
+++ b/docs/src/content/docs/examples/file-tree.mdx
@@ -1,8 +1,11 @@
 ---
 title: File Tree
+pagefind: false
 ---
 
-import { FileTree } from '@astrojs/starlight/components';
+A structure of a directory rendered with the [`<FileTree>` component](https://starlight.astro.build/components/file-tree/).
+
+import { FileTree } from '@astrojs/starlight/components'
 
 <FileTree>
 

--- a/docs/src/content/docs/examples/hero.md
+++ b/docs/src/content/docs/examples/hero.md
@@ -1,22 +1,25 @@
 ---
 title: Hero
+pagefind: false
 template: splash
 hero:
-  title: Lorem Ipsum
-  tagline: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  title: Hero title
+  tagline: A tagline for the hero section.
   image:
     file: ../../../assets/hero.webp
   actions:
-    - text: Phasellus tincidunt
-      link: /starlight-theme-flexoki/getting-started/
+    - text: Primary action
+      link: '#_'
       icon: right-arrow
       variant: primary
-    - text: Vestibulum
-      link: /starlight-theme-flexoki/getting-started/
+    - text: Secondary action
+      link: '#_'
       icon: right-arrow
       variant: secondary
-    - text: Morbi in
-      link: /starlight-theme-flexoki/getting-started/
+    - text: Minimal action
+      link: '#_'
       icon: external
       variant: minimal
 ---
+
+A page using the [`splash` template](https://starlight.astro.build/reference/frontmatter/#template) with a [`hero`](https://starlight.astro.build/reference/frontmatter/#banner) component at the top.

--- a/docs/src/content/docs/examples/kitchen-sink.mdx
+++ b/docs/src/content/docs/examples/kitchen-sink.mdx
@@ -1,204 +1,225 @@
 ---
 title: Kitchen sink
-description: Demonstration of different components and content types with this colour scheme.
+pagefind: false
 sidebar:
   order: 1
-  label: Kitchen sink
   badge: Demo
 ---
 
-This page includes a wide variety of different components to show how these look together when using this theme.
-See the following pages for examples of individual components.
-
-Learn more about components in Starlight’s [“Using components”](https://starlight.astro.build/components/using-components/) guide.
+A page with a wide variety of different [Markdown syntax](https://starlight.astro.build/guides/authoring-content/) or [components](https://starlight.astro.build/components/using-components/) to show how these look together.
+See the following pages for individual examples.
 
 ## Asides
 
 :::note
-A `:::note` block or `<Aside type="note">` looks like this.
+A `:::note` or `<Aside type="note">` aside with a [link](#_) in the content.
 :::
 
 :::tip
-A `:::tip` block or `<Aside type="tip">` looks like this.
+A `:::tip` or `<Aside type="tip">` aside with a [link](#_) in the content.
 :::
 
 :::caution
-A `:::caution` block or `<Aside type="caution">` looks like this.
+A `:::caution` or `<Aside type="caution">` aside with a [link](#_) in the content.
 :::
 
 :::danger
-A `:::danger` block or `<Aside type="danger">` looks like this.
+A `:::danger` or `<Aside type="danger">` aside with a [link](#_) in the content.
 :::
-
-## Blockquotes
-
-> Be not afeard; the isle is full of noises,  
-> Sounds and sweet airs, that give delight and hurt not.
-
-## Cards
-
-import { Card, CardGrid } from '@astrojs/starlight/components';
-
-<CardGrid>
-	<Card title="Check this out" icon="open-book">
-		Interesting content you want to highlight.
-	</Card>
-	<Card title="Other feature" icon="information">
-		More information you want to share.
-	</Card>
-	<Card title="Computer stuff" icon="laptop">
-		Build internet things with your computation machine.
-	</Card>
-	<Card title="Starlight ready" icon="starlight">
-		Just add Starlight and this theme comes to life.
-	</Card>
-</CardGrid>
-
-## Link cards
-
-import { LinkCard } from '@astrojs/starlight/components';
-
-<LinkCard
-	title="Internationalization"
-	href="https://starlight.astro.build/guides/i18n/"
-	description="Configure Starlight to support multiple languages."
-/>
 
 ## Badges
 
-import { Badge } from '@astrojs/starlight/components';
+import { Badge } from '@astrojs/starlight/components'
 
-<p>
-	<Badge text="Note" variant="note" />
-	<Badge text="Success" variant="success" />
-	<Badge text="Tip" variant="tip" />
-	<Badge text="Caution" variant="caution" />
-	<Badge text="Danger" variant="danger" />
-</p>
+- <Badge text="New" variant="tip" size="small" />
+- <Badge text="Deprecated" variant="caution" size="medium" />
+- <Badge text="Demo" variant="note" size="large" />
+- <Badge text="200" variant="success" />
+- <Badge text="Experimental" variant="danger" />
 
-### Different sizes
+## Blockquotes
 
-<p>
-	<Badge text="Small" size="small" />
-	<Badge text="Medium" size="medium" />
-	<Badge text="Large" size="large" />
-</p>
+> The content of the quote can use **any** other Markdown syntax.
 
-## Code
+## Cards
 
-### With an editor frame
+import { Card } from '@astrojs/starlight/components'
 
-```astro title="example.astro" {6} ins="insertions" del="deletions"
+<Card title="Card title">
+  The content of the card that can use any other Markdown syntax.
+</Card>
+
+### Card grid
+
+import { CardGrid } from '@astrojs/starlight/components'
+
+<CardGrid>
+  <Card title="Card title" icon="star">
+    The content of the card.
+  </Card>
+  <Card title="Card title" icon="moon">
+    The content of the card.
+  </Card>
+</CardGrid>
+
+### Link card
+
+import { LinkCard } from '@astrojs/starlight/components'
+
+<LinkCard
+  title="Link title"
+  description="The description of the link."
+  href="#_"
+/>
+
+### Link card grid
+
+<CardGrid>
+  <LinkCard title="Link title" href="#_" />
+  <LinkCard title="Link title" href="#_" />
+</CardGrid>
+
+## Details
+
+<details>
+<summary>The summary of the disclosure</summary>
+
+The content of the [disclosure](https://starlight.astro.build/guides/authoring-content/#details) that can use any other Markdown syntax.
+
+</details>
+
+## Code Blocks
+
+```astro title="example.astro" {7} ins="insertions" del="deletions"
 ---
-// this is a code block example
+// A code block example
 ---
-<p>Code can include something dynamic: {Astro.props.variable}</p>
 
-Or highlight important lines!
+<p>A paragraph with a variable: {Astro.props.foo}</p>
+
+With highlighted content.
 
 Including insertions or deletions.
 ```
 
-### Terminal commands
+### Diff
 
-```sh
-echo "Welcome, world!"
-```
-
-### Basic
-
-Code block without a frame:
-
-```js
-// for example
-console.log('Welcome, world!');
+```diff lang="js"
+  function test() {
+-   const foo = 'bar'
++   const foo = 'baz'
+  }
 ```
 
 ### Labels
 
-```jsx {"1":5} del={"2":7-8} ins={"3":10}
-// labeled-line-markers.jsx
-<button
-	role="button"
-	{...props}
-	value={value}
-	className={buttonClassName}
-	disabled={disabled}
-	active={active}
->
-	{children && !active && (typeof children === 'string' ? <span>{children}</span> : children)}
-</button>
+```astro title="example.astro" {"1. Keep the existing icon.":5-6} del={"2. Remove the button.":8-9} ins={"3. Add a link.":11-12}
+---
+import { Icon } from '@astrojs/starlight/components';
+---
+
+
+<Icon name="seti:lock" />
+
+
+<button type="button">Login</button>
+
+
+<a href="/login/">Login</a>
 ```
 
-## File tree
+### Terminal frame
 
-import { FileTree } from '@astrojs/starlight/components';
+```bash title="Build something…"
+pnpm run build
+```
+
+## File Tree
+
+import { FileTree } from '@astrojs/starlight/components'
 
 <FileTree>
 
-- astro.config.mjs
+- astro.config.mjs an **important** file
 - package.json
+- README.md
 - src
   - components
-    - Header.astro
-    - Title.astro
-  - pages/
+    - **Header.astro**
+  - …
+- pages/
 
 </FileTree>
 
-## Link buttons
+## Link Buttons
 
-import { LinkButton } from '@astrojs/starlight/components';
+import { LinkButton } from '@astrojs/starlight/components'
 
-<LinkButton href="/starlight-theme-flexoki/getting-started/">Get started</LinkButton>
-<LinkButton href="/starlight-theme-flexoki/configuration/" variant="secondary">
-	Configuration Reference
+<LinkButton href="#_" icon="rocket">
+  Primary
 </LinkButton>
-<LinkButton href="/starlight-theme-flexoki/configuration/" variant="minimal" icon="external">
-	Learn more
+<LinkButton href="#_" variant="secondary" icon="external">
+  Secondary
+</LinkButton>
+<LinkButton href="#_" variant="minimal" icon="external">
+  Minimal
 </LinkButton>
 
 ## Steps
 
-import { Steps } from '@astrojs/starlight/components';
+import { Steps } from '@astrojs/starlight/components'
 
 <Steps>
 
-1. Import the component into your MDX file:
+1. The first step of the guide that can use **any** other Markdown syntax.
 
    ```js
-   import { Steps } from '@astrojs/starlight/components';
+   const foo = 'bar'
    ```
 
-2. Wrap `<Steps>` around your ordered list items.
+2. A second and final step.
 
 </Steps>
 
 ## Tabs
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 <Tabs>
-	<TabItem label="Stars" icon="star">
-		Sirius, Vega, Betelgeuse
-	</TabItem>
-	<TabItem label="Moons" icon="moon">
-		Io, Europa, Ganymede
-	</TabItem>
+
+<TabItem label="npm" icon="seti:npm">
+
+```sh
+npm install starlight-minimalistic-theme
+```
+
+</TabItem>
+
+<TabItem label="pnpm" icon="pnpm">
+
+```sh
+pnpm add starlight-minimalistic-theme
+```
+
+</TabItem>
+
+<TabItem label="Yarn" icon="seti:yarn">
+
+```sh
+yarn add starlight-minimalistic-theme
+```
+
+</TabItem>
+
 </Tabs>
-
-## Details
-
-<details>
-<summary>Where and when is the Andromeda constellation most visible?</summary>
-
-The [Andromeda constellation](<https://en.wikipedia.org/wiki/Andromeda_(constellation)>) is most visible in the night sky during the month of November at latitudes between `+90°` and `−40°`.
-
-</details>
 
 ## Tables
 
-| Left         |     Centered     |                      Right |
-| :----------- | :--------------: | -------------------------: |
-| This is left | Text is centered |  And this is right-aligned |
-| More text    |  Even more text  | And even more to the right |
+| Column 1 | Column 2 | Column 3 | Column 4 |
+| -------- | -------- | -------- | -------- |
+| Cell 1-1 | Cell 1-2 | Cell 1-3 | Cell 1-4 |
+| Cell 2-1 | Cell 2-2 | Cell 2-3 | Cell 2-4 |
+| Cell 3-1 | Cell 3-2 | Cell 3-3 | Cell 3-4 |
+| Cell 4-1 | Cell 4-2 | Cell 4-3 | Cell 4-4 |
+| Cell 5-1 | Cell 5-2 | Cell 5-3 | Cell 5-4 |
+| Cell 6-1 | Cell 6-2 | Cell 6-3 | Cell 6-4 |

--- a/docs/src/content/docs/examples/kitchen-sink.mdx
+++ b/docs/src/content/docs/examples/kitchen-sink.mdx
@@ -67,21 +67,17 @@ import { LinkCard } from '@astrojs/starlight/components';
 
 import { Badge } from '@astrojs/starlight/components';
 
-<p>
-	<Badge text="Note" variant="note" />
-	<Badge text="Success" variant="success" />
-	<Badge text="Tip" variant="tip" />
-	<Badge text="Caution" variant="caution" />
-	<Badge text="Danger" variant="danger" />
-</p>
+- <Badge text="Note" variant="note" />
+- <Badge text="Success" variant="success" />
+- <Badge text="Tip" variant="tip" />
+- <Badge text="Caution" variant="caution" />
+- <Badge text="Danger" variant="danger" />
 
 ### Different sizes
 
-<p>
-	<Badge text="Small" size="small" />
-	<Badge text="Medium" size="medium" />
-	<Badge text="Large" size="large" />
-</p>
+- <Badge text="Small" size="small" />
+- <Badge text="Medium" size="medium" />
+- <Badge text="Large" size="large" />
 
 ## Code
 

--- a/docs/src/content/docs/examples/kitchen-sink.mdx
+++ b/docs/src/content/docs/examples/kitchen-sink.mdx
@@ -1,16 +1,15 @@
 ---
 title: Kitchen sink
 description: Demonstration of different components and content types with this colour scheme.
+pagefind: false
 sidebar:
   order: 1
   label: Kitchen sink
   badge: Demo
 ---
 
-This page includes a wide variety of different components to show how these look together when using this theme.
-See the following pages for examples of individual components.
-
-Learn more about components in Starlight’s [“Using components”](https://starlight.astro.build/components/using-components/) guide.
+A page with a wide variety of different [Markdown syntax](https://starlight.astro.build/guides/authoring-content/) or [components](https://starlight.astro.build/components/using-components/) to show how these look together.
+See the following pages for individual examples.
 
 ## Asides
 

--- a/docs/src/content/docs/examples/kitchen-sink.mdx
+++ b/docs/src/content/docs/examples/kitchen-sink.mdx
@@ -1,225 +1,204 @@
 ---
 title: Kitchen sink
-pagefind: false
+description: Demonstration of different components and content types with this colour scheme.
 sidebar:
   order: 1
+  label: Kitchen sink
   badge: Demo
 ---
 
-A page with a wide variety of different [Markdown syntax](https://starlight.astro.build/guides/authoring-content/) or [components](https://starlight.astro.build/components/using-components/) to show how these look together.
-See the following pages for individual examples.
+This page includes a wide variety of different components to show how these look together when using this theme.
+See the following pages for examples of individual components.
+
+Learn more about components in Starlight’s [“Using components”](https://starlight.astro.build/components/using-components/) guide.
 
 ## Asides
 
 :::note
-A `:::note` or `<Aside type="note">` aside with a [link](#_) in the content.
+A `:::note` block or `<Aside type="note">` looks like this.
 :::
 
 :::tip
-A `:::tip` or `<Aside type="tip">` aside with a [link](#_) in the content.
+A `:::tip` block or `<Aside type="tip">` looks like this.
 :::
 
 :::caution
-A `:::caution` or `<Aside type="caution">` aside with a [link](#_) in the content.
+A `:::caution` block or `<Aside type="caution">` looks like this.
 :::
 
 :::danger
-A `:::danger` or `<Aside type="danger">` aside with a [link](#_) in the content.
+A `:::danger` block or `<Aside type="danger">` looks like this.
 :::
-
-## Badges
-
-import { Badge } from '@astrojs/starlight/components'
-
-- <Badge text="New" variant="tip" size="small" />
-- <Badge text="Deprecated" variant="caution" size="medium" />
-- <Badge text="Demo" variant="note" size="large" />
-- <Badge text="200" variant="success" />
-- <Badge text="Experimental" variant="danger" />
 
 ## Blockquotes
 
-> The content of the quote can use **any** other Markdown syntax.
+> Be not afeard; the isle is full of noises,  
+> Sounds and sweet airs, that give delight and hurt not.
 
 ## Cards
 
-import { Card } from '@astrojs/starlight/components'
-
-<Card title="Card title">
-  The content of the card that can use any other Markdown syntax.
-</Card>
-
-### Card grid
-
-import { CardGrid } from '@astrojs/starlight/components'
+import { Card, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
-  <Card title="Card title" icon="star">
-    The content of the card.
-  </Card>
-  <Card title="Card title" icon="moon">
-    The content of the card.
-  </Card>
+	<Card title="Check this out" icon="open-book">
+		Interesting content you want to highlight.
+	</Card>
+	<Card title="Other feature" icon="information">
+		More information you want to share.
+	</Card>
+	<Card title="Computer stuff" icon="laptop">
+		Build internet things with your computation machine.
+	</Card>
+	<Card title="Starlight ready" icon="starlight">
+		Just add Starlight and this theme comes to life.
+	</Card>
 </CardGrid>
 
-### Link card
+## Link cards
 
-import { LinkCard } from '@astrojs/starlight/components'
+import { LinkCard } from '@astrojs/starlight/components';
 
 <LinkCard
-  title="Link title"
-  description="The description of the link."
-  href="#_"
+	title="Internationalization"
+	href="https://starlight.astro.build/guides/i18n/"
+	description="Configure Starlight to support multiple languages."
 />
 
-### Link card grid
+## Badges
 
-<CardGrid>
-  <LinkCard title="Link title" href="#_" />
-  <LinkCard title="Link title" href="#_" />
-</CardGrid>
+import { Badge } from '@astrojs/starlight/components';
 
-## Details
+<p>
+	<Badge text="Note" variant="note" />
+	<Badge text="Success" variant="success" />
+	<Badge text="Tip" variant="tip" />
+	<Badge text="Caution" variant="caution" />
+	<Badge text="Danger" variant="danger" />
+</p>
 
-<details>
-<summary>The summary of the disclosure</summary>
+### Different sizes
 
-The content of the [disclosure](https://starlight.astro.build/guides/authoring-content/#details) that can use any other Markdown syntax.
+<p>
+	<Badge text="Small" size="small" />
+	<Badge text="Medium" size="medium" />
+	<Badge text="Large" size="large" />
+</p>
 
-</details>
+## Code
 
-## Code Blocks
+### With an editor frame
 
-```astro title="example.astro" {7} ins="insertions" del="deletions"
+```astro title="example.astro" {6} ins="insertions" del="deletions"
 ---
-// A code block example
+// this is a code block example
 ---
+<p>Code can include something dynamic: {Astro.props.variable}</p>
 
-<p>A paragraph with a variable: {Astro.props.foo}</p>
-
-With highlighted content.
+Or highlight important lines!
 
 Including insertions or deletions.
 ```
 
-### Diff
+### Terminal commands
 
-```diff lang="js"
-  function test() {
--   const foo = 'bar'
-+   const foo = 'baz'
-  }
+```sh
+echo "Welcome, world!"
+```
+
+### Basic
+
+Code block without a frame:
+
+```js
+// for example
+console.log('Welcome, world!');
 ```
 
 ### Labels
 
-```astro title="example.astro" {"1. Keep the existing icon.":5-6} del={"2. Remove the button.":8-9} ins={"3. Add a link.":11-12}
----
-import { Icon } from '@astrojs/starlight/components';
----
-
-
-<Icon name="seti:lock" />
-
-
-<button type="button">Login</button>
-
-
-<a href="/login/">Login</a>
+```jsx {"1":5} del={"2":7-8} ins={"3":10}
+// labeled-line-markers.jsx
+<button
+	role="button"
+	{...props}
+	value={value}
+	className={buttonClassName}
+	disabled={disabled}
+	active={active}
+>
+	{children && !active && (typeof children === 'string' ? <span>{children}</span> : children)}
+</button>
 ```
 
-### Terminal frame
+## File tree
 
-```bash title="Build something…"
-pnpm run build
-```
-
-## File Tree
-
-import { FileTree } from '@astrojs/starlight/components'
+import { FileTree } from '@astrojs/starlight/components';
 
 <FileTree>
 
-- astro.config.mjs an **important** file
+- astro.config.mjs
 - package.json
-- README.md
 - src
   - components
-    - **Header.astro**
-  - …
-- pages/
+    - Header.astro
+    - Title.astro
+  - pages/
 
 </FileTree>
 
-## Link Buttons
+## Link buttons
 
-import { LinkButton } from '@astrojs/starlight/components'
+import { LinkButton } from '@astrojs/starlight/components';
 
-<LinkButton href="#_" icon="rocket">
-  Primary
+<LinkButton href="/starlight-theme-flexoki/getting-started/">Get started</LinkButton>
+<LinkButton href="/starlight-theme-flexoki/configuration/" variant="secondary">
+	Configuration Reference
 </LinkButton>
-<LinkButton href="#_" variant="secondary" icon="external">
-  Secondary
-</LinkButton>
-<LinkButton href="#_" variant="minimal" icon="external">
-  Minimal
+<LinkButton href="/starlight-theme-flexoki/configuration/" variant="minimal" icon="external">
+	Learn more
 </LinkButton>
 
 ## Steps
 
-import { Steps } from '@astrojs/starlight/components'
+import { Steps } from '@astrojs/starlight/components';
 
 <Steps>
 
-1. The first step of the guide that can use **any** other Markdown syntax.
+1. Import the component into your MDX file:
 
    ```js
-   const foo = 'bar'
+   import { Steps } from '@astrojs/starlight/components';
    ```
 
-2. A second and final step.
+2. Wrap `<Steps>` around your ordered list items.
 
 </Steps>
 
 ## Tabs
 
-import { Tabs, TabItem } from '@astrojs/starlight/components'
+import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 <Tabs>
-
-<TabItem label="npm" icon="seti:npm">
-
-```sh
-npm install starlight-minimalistic-theme
-```
-
-</TabItem>
-
-<TabItem label="pnpm" icon="pnpm">
-
-```sh
-pnpm add starlight-minimalistic-theme
-```
-
-</TabItem>
-
-<TabItem label="Yarn" icon="seti:yarn">
-
-```sh
-yarn add starlight-minimalistic-theme
-```
-
-</TabItem>
-
+	<TabItem label="Stars" icon="star">
+		Sirius, Vega, Betelgeuse
+	</TabItem>
+	<TabItem label="Moons" icon="moon">
+		Io, Europa, Ganymede
+	</TabItem>
 </Tabs>
+
+## Details
+
+<details>
+<summary>Where and when is the Andromeda constellation most visible?</summary>
+
+The [Andromeda constellation](<https://en.wikipedia.org/wiki/Andromeda_(constellation)>) is most visible in the night sky during the month of November at latitudes between `+90°` and `−40°`.
+
+</details>
 
 ## Tables
 
-| Column 1 | Column 2 | Column 3 | Column 4 |
-| -------- | -------- | -------- | -------- |
-| Cell 1-1 | Cell 1-2 | Cell 1-3 | Cell 1-4 |
-| Cell 2-1 | Cell 2-2 | Cell 2-3 | Cell 2-4 |
-| Cell 3-1 | Cell 3-2 | Cell 3-3 | Cell 3-4 |
-| Cell 4-1 | Cell 4-2 | Cell 4-3 | Cell 4-4 |
-| Cell 5-1 | Cell 5-2 | Cell 5-3 | Cell 5-4 |
-| Cell 6-1 | Cell 6-2 | Cell 6-3 | Cell 6-4 |
+| Left         |     Centered     |                      Right |
+| :----------- | :--------------: | -------------------------: |
+| This is left | Text is centered |  And this is right-aligned |
+| More text    |  Even more text  | And even more to the right |

--- a/docs/src/content/docs/examples/link-buttons.mdx
+++ b/docs/src/content/docs/examples/link-buttons.mdx
@@ -1,27 +1,32 @@
 ---
 title: Link Buttons
+pagefind: false
 ---
 
-import { LinkButton } from '@astrojs/starlight/components';
+import { LinkButton } from '@astrojs/starlight/components'
 
 ## No icons
 
-<LinkButton href="/starlight-theme-flexoki/getting-started/">Get started</LinkButton>
-<LinkButton href="https://starlight.astro.build/" variant="secondary">
-	Related: Starlight
+Link buttons rendered with the [`<LinkButton>` component](https://starlight.astro.build/components/link-buttons/).
+
+<LinkButton href="#_">Primary</LinkButton>
+<LinkButton href="#_" variant="secondary">
+  Secondary
 </LinkButton>
-<LinkButton href="https://docs.astro.build/" variant="minimal">
-	Related: Astro
+<LinkButton href="#_" variant="minimal">
+  Minimal
 </LinkButton>
 
 ## With icons
 
-<LinkButton href="/starlight-theme-flexoki/getting-started/" icon="rocket">
-	Get started
+Link buttons rendered with the [`<LinkButton>` component](https://starlight.astro.build/components/link-buttons/) and [an icon](https://starlight.astro.build/components/link-buttons/#add-icons-to-link-buttons).
+
+<LinkButton href="#_" icon="rocket">
+  Primary
 </LinkButton>
-<LinkButton href="https://starlight.astro.build/" variant="secondary" icon="external">
-	Related: Starlight
+<LinkButton href="#_" variant="secondary" icon="external">
+  Secondary
 </LinkButton>
-<LinkButton href="https://docs.astro.build/" variant="minimal" icon="external">
-	Related: Astro
+<LinkButton href="#_" variant="minimal" icon="external">
+  Minimal
 </LinkButton>

--- a/docs/src/content/docs/examples/markdown.md
+++ b/docs/src/content/docs/examples/markdown.md
@@ -1,58 +1,59 @@
 ---
 title: Markdown
+pagefind: false
 ---
 
 ## Heading 2
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eu ante elementum, ultrices massa ut, ornare lacus. Praesent iaculis, ex ac pellentesque malesuada, arcu mi imperdiet purus, et molestie neque leo quis felis. Nunc et odio bibendum, vestibulum elit sit amet, viverra lorem.
+Some text content used as a placeholder for the purpose of this example page. The content is not meant to be meaningful or relevant, but rather to preview how the page will look with actual content.
 
 ### Heading 3
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eu ante elementum, ultrices massa ut, ornare lacus. Praesent iaculis, ex ac pellentesque malesuada, arcu mi imperdiet purus, et molestie neque leo quis felis. Nunc et odio bibendum, vestibulum elit sit amet, viverra lorem.
+Some text content used as a placeholder for the purpose of this example page. The content is not meant to be meaningful or relevant, but rather to preview how the page will look with actual content.
 
 #### Heading 4
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eu ante elementum, ultrices massa ut, ornare lacus. Praesent iaculis, ex ac pellentesque malesuada, arcu mi imperdiet purus, et molestie neque leo quis felis. Nunc et odio bibendum, vestibulum elit sit amet, viverra lorem.
+Some text content used as a placeholder for the purpose of this example page. The content is not meant to be meaningful or relevant, but rather to preview how the page will look with actual content.
 
 ##### Heading 5
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eu ante elementum, ultrices massa ut, ornare lacus. Praesent iaculis, ex ac pellentesque malesuada, arcu mi imperdiet purus, et molestie neque leo quis felis. Nunc et odio bibendum, vestibulum elit sit amet, viverra lorem.
+Some text content used as a placeholder for the purpose of this example page. The content is not meant to be meaningful or relevant, but rather to preview how the page will look with actual content.
 
 ###### Heading 6
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eu ante elementum, ultrices massa ut, ornare lacus. Praesent iaculis, ex ac pellentesque malesuada, arcu mi imperdiet purus, et molestie neque leo quis felis. Nunc et odio bibendum, vestibulum elit sit amet, viverra lorem.
+Some text content used as a placeholder for the purpose of this example page. The content is not meant to be meaningful or relevant, but rather to preview how the page will look with actual content.
 
 ## Styling text
 
-Fusce imperdiet, **tellus** ornare tempor _cursus_, tellus ipsum fringilla ~~quam~~, in venenatis neque augue vitae **_turpis_**. Nulla sed neque volutpat, eleifend purus <sub>sit amet</sub>, porttitor nisi. Ut id sodales lorem. Suspendisse <sup>auctor</sup> augue nisl, sed placerat enim porttitor at. Etiam eu ipsum suscipit, egestas ante non, eleifend nulla.
+Some text content with some **bold** text, _italic_ text, ~~strikethrough~~ text, and some **_bold italic_** text. Some text can also be displayed as <sub>subscript</sub> or <sup>superscript</sup>.
 
 ## Quoting text
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla in enim sem.
+Some text content can be quoted using the `>` character.
 
-> Mauris dictum augue augue, ut accumsan tellus convallis ut. Nam vitae libero vestibulum, feugiat mi rhoncus, imperdiet dui. In eros diam, sagittis ultrices dolor ac, ultrices cursus sapien. Morbi fringilla porta purus, sed interdum urna luctus vitae.
+> The content of the quote can use **any** other Markdown syntax.
 
-## Quoting code
+## Code
 
-Curabitur congue ac `enim` id hendrerit.
+Code can be displayed `inline` or in a code block.
 
 ```js
-const foo = 'bar';
+const foo = 'bar'
 ```
 
 ## Links
 
-Fusce tincidunt urna at [ultricies](#_) sollicitudin.
+Some text content with a [link](#_) to another page.
 
 ## Lists
 
-- Lorem
-- Ipsum
-  - Dolor
-  - Sit
-- Amet
-  1. Consectetur
-  2. Adipiscing
+- List items
+- can
+  - be
+  - nested
+- and
+  1. be
+  2. numbered
 
 ## Tables
 
@@ -67,9 +68,11 @@ Fusce tincidunt urna at [ultricies](#_) sollicitudin.
 
 ## Details
 
-<details>
-<summary>Nullam nec posuere lorem.</summary>
+Details (also known as “disclosures” or “accordions”) can be used to hide content that is not immediately relevant.
 
-Aenean tempor, orci eget ullamcorper luctus, nisl turpis pharetra mauris, sit amet tristique elit orci et sem. Aenean odio purus, suscipit quis accumsan in, blandit at ex.
+<details>
+<summary>The summary of the disclosure</summary>
+
+The content of the [disclosure](https://starlight.astro.build/guides/authoring-content/#details) that can use any other Markdown syntax.
 
 </details>

--- a/docs/src/content/docs/examples/steps.mdx
+++ b/docs/src/content/docs/examples/steps.mdx
@@ -1,28 +1,31 @@
 ---
 title: Steps
+pagefind: false
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+A numbered list of tasks used to create a step-by-step guide rendered with the [`<Steps>` component](https://starlight.astro.build/components/steps/).
+
+import { Steps } from '@astrojs/starlight/components'
 
 <Steps>
 
-1. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+1. The first step of the guide that can use **any** other Markdown syntax.
 
    ```js
-   const foo = 'bar';
+   const foo = 'bar'
    ```
 
-2. Aenean nisi sem, maximus at fringilla a, tempor non diam.
+2. A second step with a nested list of tasks.
 
    <Steps>
 
-   1. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+   1. A nested step of the guide that can use **any** other Markdown syntax.
 
       ```js
-      const foo = 'bar';
+      const foo = 'bar'
       ```
 
-   2. Aenean nisi sem, maximus at fringilla a, tempor non diam.
+   2. And a final step.
 
    </Steps>
 

--- a/docs/src/content/docs/examples/tabs.mdx
+++ b/docs/src/content/docs/examples/tabs.mdx
@@ -1,26 +1,33 @@
 ---
 title: Tabs
+pagefind: false
 ---
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { Tabs, TabItem } from '@astrojs/starlight/components'
+
+## No icons
+
+A tabbed interface rendered with the [`<Tabs>` and `<TabItem>` components](https://starlight.astro.build/components/tabs/).
 
 <Tabs>
-	<TabItem label="Lorem">
-		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce ornare ante est, eget molestie
-		arcu euismod eu. Suspendisse ac tincidunt tellus, sed vehicula eros.
-	</TabItem>
-	<TabItem label="Ipsum">
-		Nam condimentum, lorem eget scelerisque pellentesque, arcu sapien fringilla ligula, eget dictum
-		lectus odio in mi.
-	</TabItem>
+  <TabItem label="A tab">
+    The first tab content that can use **any** other Markdown syntax.
+  </TabItem>
+  <TabItem label="Another tab">
+    The content of the second tab that can also use **any** other Markdown syntax.
+  </TabItem>
 </Tabs>
 
-<Tabs syncKey="pkg">
+## With icons
+
+A tabbed interface rendered with the [`<Tabs>` and `<TabItem>` components](https://starlight.astro.build/components/tabs/) and [icons](https://starlight.astro.build/components/tabs/#add-icons-to-tabs).
+
+<Tabs>
 
 <TabItem label="npm" icon="seti:npm">
 
 ```sh
-npm install starlight-theme-flexoki
+npm install starlight-minimalistic-theme
 ```
 
 </TabItem>
@@ -28,7 +35,7 @@ npm install starlight-theme-flexoki
 <TabItem label="pnpm" icon="pnpm">
 
 ```sh
-pnpm add starlight-theme-flexoki
+pnpm add starlight-minimalistic-theme
 ```
 
 </TabItem>
@@ -36,7 +43,7 @@ pnpm add starlight-theme-flexoki
 <TabItem label="Yarn" icon="seti:yarn">
 
 ```sh
-yarn add starlight-theme-flexoki
+yarn add starlight-minimalistic-theme
 ```
 
 </TabItem>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -81,17 +81,4 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
   </Card>
 
-  <Card title="Preview the theme" icon="seti:image">
-
-    Check out the [example pages](/starlight-theme-flexoki/examples/kitchen-sink/) to see the theme in
-    action.
-
-  </Card>
-
-  <Card title="Read the docs" icon="open-book">
-
-    Learn more in the [Starlight Flexoki Docs](/starlight-theme-flexoki/getting-started/).
-
-  </Card>
-
 </CardGrid>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -22,6 +22,10 @@ hero:
     - text: Get Started
       link: /starlight-theme-flexoki/getting-started/
       icon: right-arrow
+    - text: Examples
+      link: /starlight-theme-flexoki/examples/kitchen-sink/
+      icon: right-arrow
+      variant: minimal
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
@@ -74,6 +78,19 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
     </p>
 
     See the [“Configuration”](/starlight-theme-flexoki/configuration/) reference for details.
+
+  </Card>
+
+  <Card title="Preview the theme" icon="seti:image">
+
+    Check out the [example pages](/starlight-theme-flexoki/examples/kitchen-sink/) to see the theme in
+    action.
+
+  </Card>
+
+  <Card title="Read the docs" icon="open-book">
+
+    Learn more in the [Starlight Flexoki Docs](/starlight-theme-flexoki/getting-started/).
 
   </Card>
 


### PR DESCRIPTION
HiDeoo recently released a very nice addition to the plugin generator, where you can now generate themes. This features very well thought out examples pages, so I give you, Chris, the option to update these examples with the new examples as well.

Feel free to request changes, discard the whole PR or merge it as you like!

This is mostly a backport of [HiDeoo/generator-starlight-plugin#17](https://github.com/HiDeoo/generator-starlight-plugin/pull/17)