### PR TITLE
Use Node 24 for trusted publishing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
-          node-version: 20.19.5
+          node-version: 24.10.0
           cache: 'pnpm'
 
       - run: pnpm i


### PR DESCRIPTION
Forgot in #18 to use Node 24