### PR TITLE
Fix text alignment in pagination when page titles wrap to multiple lines

### DIFF
--- a/.changeset/nasty-sites-double.md
+++ b/.changeset/nasty-sites-double.md
@@ -1,0 +1,5 @@
+---
+"starlight-theme-flexoki": patch
+---
+
+Fix text alignment in pagination when page titles wrap to multiple lines

--- a/packages/starlight-theme-flexoki/overrides/Pagination.astro
+++ b/packages/starlight-theme-flexoki/overrides/Pagination.astro
@@ -1,38 +1,38 @@
 ---
-import { Icon } from "@astrojs/starlight/components";
+import { Icon } from '@astrojs/starlight/components';
 
 const { dir, pagination } = Astro.locals.starlightRoute;
 const { prev, next } = pagination;
-const isRtl = dir === "rtl";
+const isRtl = dir === 'rtl';
 
 if (!prev && !next) {
-  return;
+	return;
 }
 ---
 
 <div class="pagination-links print:hidden" {dir}>
-  {
-    prev && (
-      <a href={prev.href} rel="prev" class="sl-flex">
-        <span class="eyebrow sl-flex">
-          <Icon name={isRtl ? "right-arrow" : "left-arrow"} size="1.5em" />
-          {Astro.locals.t("page.previousLink")}
-        </span>
-        <span class="link-title">{prev.label}</span>
-      </a>
-    )
-  }
-  {
-    next && (
-      <a href={next.href} rel="next" class="sl-flex">
-        <span class="eyebrow sl-flex">
-          {Astro.locals.t("page.nextLink")}
-          <Icon name={isRtl ? "left-arrow" : "right-arrow"} size="1.5em" />
-        </span>
-        <span class="link-title">{next.label}</span>
-      </a>
-    )
-  }
+	{
+		prev && (
+			<a href={prev.href} rel="prev" class="sl-flex">
+				<span class="eyebrow sl-flex">
+					<Icon name={isRtl ? 'right-arrow' : 'left-arrow'} size="1.5em" />
+					{Astro.locals.t('page.previousLink')}
+				</span>
+				<span class="link-title">{prev.label}</span>
+			</a>
+		)
+	}
+	{
+		next && (
+			<a href={next.href} rel="next" class="sl-flex">
+				<span class="eyebrow sl-flex">
+					{Astro.locals.t('page.nextLink')}
+					<Icon name={isRtl ? 'left-arrow' : 'right-arrow'} size="1.5em" />
+				</span>
+				<span class="link-title">{next.label}</span>
+			</a>
+		)
+	}
 </div>
 
 <style>
@@ -52,7 +52,7 @@ if (!prev && !next) {
       width: 100%;
       flex-grow: 1;
 
-      &[rel="next"] {
+      &[rel='next'] {
         align-items: flex-end;
         text-align: end;
       }
@@ -69,7 +69,7 @@ if (!prev && !next) {
     }
     svg {
       margin-inline: -0.1875em 0;
-      [rel="next"] & {
+      [rel='next'] & {
         margin-inline: 0 -0.1875em;
       }
     }

--- a/packages/starlight-theme-flexoki/overrides/Pagination.astro
+++ b/packages/starlight-theme-flexoki/overrides/Pagination.astro
@@ -1,38 +1,38 @@
 ---
-import { Icon } from '@astrojs/starlight/components';
+import { Icon } from "@astrojs/starlight/components";
 
 const { dir, pagination } = Astro.locals.starlightRoute;
 const { prev, next } = pagination;
-const isRtl = dir === 'rtl';
+const isRtl = dir === "rtl";
 
 if (!prev && !next) {
-	return;
+  return;
 }
 ---
 
 <div class="pagination-links print:hidden" {dir}>
-	{
-		prev && (
-			<a href={prev.href} rel="prev" class="sl-flex">
-				<span class="eyebrow sl-flex">
-					<Icon name={isRtl ? 'right-arrow' : 'left-arrow'} size="1.5em" />
-					{Astro.locals.t('page.previousLink')}
-				</span>
-				<span class="link-title">{prev.label}</span>
-			</a>
-		)
-	}
-	{
-		next && (
-			<a href={next.href} rel="next" class="sl-flex">
-				<span class="eyebrow sl-flex">
-					{Astro.locals.t('page.nextLink')}
-					<Icon name={isRtl ? 'left-arrow' : 'right-arrow'} size="1.5em" />
-				</span>
-				<span class="link-title">{next.label}</span>
-			</a>
-		)
-	}
+  {
+    prev && (
+      <a href={prev.href} rel="prev" class="sl-flex">
+        <span class="eyebrow sl-flex">
+          <Icon name={isRtl ? "right-arrow" : "left-arrow"} size="1.5em" />
+          {Astro.locals.t("page.previousLink")}
+        </span>
+        <span class="link-title">{prev.label}</span>
+      </a>
+    )
+  }
+  {
+    next && (
+      <a href={next.href} rel="next" class="sl-flex">
+        <span class="eyebrow sl-flex">
+          {Astro.locals.t("page.nextLink")}
+          <Icon name={isRtl ? "left-arrow" : "right-arrow"} size="1.5em" />
+        </span>
+        <span class="link-title">{next.label}</span>
+      </a>
+    )
+  }
 </div>
 
 <style>
@@ -52,8 +52,9 @@ if (!prev && !next) {
       width: 100%;
       flex-grow: 1;
 
-      &[rel='next'] {
+      &[rel="next"] {
         align-items: flex-end;
+        text-align: end;
       }
 
       &:hover,
@@ -68,7 +69,7 @@ if (!prev && !next) {
     }
     svg {
       margin-inline: -0.1875em 0;
-      [rel='next'] & {
+      [rel="next"] & {
         margin-inline: 0 -0.1875em;
       }
     }


### PR DESCRIPTION
Fix the following issue:

<img width="1170" height="349" alt="image" src="https://github.com/user-attachments/assets/7ec4254f-2ac1-452a-8d44-579bc1480ae2" />

Verified locally:

<img width="1146" height="274" alt="CleanShot 2026-07-27 at 08 40 56@2x" src="https://github.com/user-attachments/assets/ee49c1a8-d442-4072-8df8-ba59b6958cab" />